### PR TITLE
Define Android specific cmake variables ANDROID_ABI/ANDROID_NDK

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -65,6 +65,12 @@ class LibwebpConan(ConanFile):
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_TIFF'] = True
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_JPEG'] = True
 
+        if self.settings.os == "Android":
+            cmake.definitions['ANDROID_ABI'] = cmake.definitions['CMAKE_ANDROID_ARCH_ABI']
+
+            if 'ANDROID_NDK_HOME' in os.environ:
+                cmake.definitions['ANDROID_NDK'] = os.environ.get('ANDROID_NDK_HOME')
+
         cmake.configure(source_folder=self._source_subfolder)
         return cmake
 


### PR DESCRIPTION
Without this variables, cmake configuration process failed

So till https://github.com/conan-io/conan/issues/3099 will approved/implemented, I kindly ask you to review/approve this PR